### PR TITLE
hyprland: preserve Num Lock state across sessions

### DIFF
--- a/dots/.config/hypr/hyprland/general.lua
+++ b/dots/.config/hypr/hyprland/general.lua
@@ -1,3 +1,44 @@
+-- Preserve Num Lock across both compositor handoffs and full reboots. The
+-- persistent value wins because the outgoing SDDM compositor may reset the
+-- hardware LED before this user compositor evaluates its configuration.
+local function inheritedNumlockState()
+    local statePath = os.getenv("HOME") .. "/.local/state/mainstream/numlock"
+    local saved = io.open(statePath, "r")
+    if saved then
+        local value = saved:read("*l")
+        saved:close()
+        if value == "1" then
+            return true
+        elseif value == "0" then
+            return false
+        end
+    end
+
+    local reader = io.popen([[
+for path in /sys/class/leds/*::numlock/brightness; do
+    [ -r "$path" ] && cat "$path"
+done
+]])
+    if not reader then
+        return true
+    end
+
+    local found = false
+    local enabled = false
+    for value in reader:lines() do
+        found = true
+        if value:match("^%s*1%s*$") then
+            enabled = true
+        end
+    end
+    reader:close()
+
+    if not found then
+        return true
+    end
+    return enabled
+end
+
 -- MONITOR CONFIG
 hl.monitor({
     output = "",
@@ -164,7 +205,7 @@ end
 hl.config({
     input = {
         kb_layout = "us",
-        numlock_by_default = true,
+        numlock_by_default = inheritedNumlockState(),
         repeat_delay = 250,
         repeat_rate = 35,
 

--- a/dots/.config/hypr/hyprland/general.lua
+++ b/dots/.config/hypr/hyprland/general.lua
@@ -1,6 +1,6 @@
--- Preserve Num Lock across both compositor handoffs and full reboots. The
--- persistent value wins because the outgoing SDDM compositor may reset the
--- hardware LED before this user compositor evaluates its configuration.
+-- Preserve Num Lock across both compositor handoffs and full reboots. Keep
+-- the existing enabled default until the user has made a saved choice: on a
+-- cold boot the hardware LEDs initially read off before anything sets them.
 local function inheritedNumlockState()
     local statePath = os.getenv("HOME") .. "/.local/state/mainstream/numlock"
     local saved = io.open(statePath, "r")
@@ -14,29 +14,7 @@ local function inheritedNumlockState()
         end
     end
 
-    local reader = io.popen([[
-for path in /sys/class/leds/*::numlock/brightness; do
-    [ -r "$path" ] && cat "$path"
-done
-]])
-    if not reader then
-        return true
-    end
-
-    local found = false
-    local enabled = false
-    for value in reader:lines() do
-        found = true
-        if value:match("^%s*1%s*$") then
-            enabled = true
-        end
-    end
-    reader:close()
-
-    if not found then
-        return true
-    end
-    return enabled
+    return true
 end
 
 -- MONITOR CONFIG

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -61,6 +61,10 @@ hl.bind("CTRL + SUPER + P", hl.dsp.global("quickshell:panelFamilyCycle"), {descr
 -- keyboard that owns the focused input, so it also works with external boards.
 hl.bind("CTRL + SUPER + K", hl.dsp.exec_cmd("hyprctl switchxkblayout current next"), {description = "Next keyboard layout"} )
 
+-- Save the new LED state after the real Num Lock event has reached Hyprland.
+-- non_consuming keeps the key's normal behaviour intact.
+hl.bind("Num_Lock", hl.dsp.exec_cmd(hyprScripts.."/save-numlock-state.sh"), {non_consuming = true} )
+
 --##! Media
 local mediaNextCommand = "playerctl next || playerctl position `bc <<< \"100 * $(playerctl metadata mpris:length) / 1000000 / 100\"`"
 hl.bind("SUPER + SHIFT + N", hl.dsp.exec_cmd(mediaNextCommand), {locked = true, description = "Next track"} )

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -62,8 +62,9 @@ hl.bind("CTRL + SUPER + P", hl.dsp.global("quickshell:panelFamilyCycle"), {descr
 hl.bind("CTRL + SUPER + K", hl.dsp.exec_cmd("hyprctl switchxkblayout current next"), {description = "Next keyboard layout"} )
 
 -- Save the new LED state after the real Num Lock event has reached Hyprland.
--- non_consuming keeps the key's normal behaviour intact.
-hl.bind("Num_Lock", hl.dsp.exec_cmd(hyprScripts.."/save-numlock-state.sh"), {non_consuming = true} )
+-- locked keeps state tracking active on the lock screen, while non_consuming
+-- preserves the key's normal behaviour.
+hl.bind("Num_Lock", hl.dsp.exec_cmd(hyprScripts.."/save-numlock-state.sh"), {locked = true, non_consuming = true} )
 
 --##! Media
 local mediaNextCommand = "playerctl next || playerctl position `bc <<< \"100 * $(playerctl metadata mpris:length) / 1000000 / 100\"`"

--- a/dots/.config/hypr/hyprland/scripts/save-numlock-state.sh
+++ b/dots/.config/hypr/hyprland/scripts/save-numlock-state.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The non-consuming Hyprland binding fires alongside the real Num Lock key,
+# so give the compositor a moment to publish the resulting LED state.
+sleep 0.1
+
+state_dir="${HOME}/.local/state/mainstream"
+state_file="${state_dir}/numlock"
+state_value=0
+found_led=0
+
+for led_file in /sys/class/leds/*::numlock/brightness; do
+    [[ -r "$led_file" ]] || continue
+    found_led=1
+    read -r led_value < "$led_file"
+    if [[ "$led_value" == "1" ]]; then
+        state_value=1
+    fi
+done
+
+(( found_led == 1 )) || exit 0
+
+install -d -m 0755 "$state_dir"
+state_tmp=$(mktemp "${state_dir}/.numlock.XXXXXX")
+trap 'rm -f "$state_tmp"' EXIT
+printf '%s\n' "$state_value" > "$state_tmp"
+chmod 0644 "$state_tmp"
+mv -f "$state_tmp" "$state_file"
+trap - EXIT

--- a/sdata/sddm/hyprland.lua
+++ b/sdata/sddm/hyprland.lua
@@ -10,6 +10,90 @@
 -- .conf config, and the greeter is the first thing anyone sees. Support for
 -- the format goes away entirely in 0.57.
 
+-- SDDM and the user session run separate Hyprland instances. Recover the last
+-- logged-in user's saved Num Lock state before the greeter configures input.
+local function persistedNumlockState()
+    local state = io.open("/var/lib/sddm/state.conf", "r")
+    if not state then
+        return nil
+    end
+
+    local username
+    for line in state:lines() do
+        username = line:match("^User%s*=%s*(.-)%s*$")
+        if username and username ~= "" then
+            break
+        end
+    end
+    state:close()
+    if not username then
+        return nil
+    end
+
+    local passwd = io.open("/etc/passwd", "r")
+    if not passwd then
+        return nil
+    end
+
+    local home
+    for line in passwd:lines() do
+        local user, userHome = line:match("^([^:]+):[^:]*:[^:]*:[^:]*:[^:]*:([^:]+):")
+        if user == username then
+            home = userHome
+            break
+        end
+    end
+    passwd:close()
+    if not home then
+        return nil
+    end
+
+    local saved = io.open(home .. "/.local/state/mainstream/numlock", "r")
+    if not saved then
+        return nil
+    end
+    local value = saved:read("*l")
+    saved:close()
+
+    if value == "1" then
+        return true
+    elseif value == "0" then
+        return false
+    end
+    return nil
+end
+
+local function inheritedNumlockState()
+    local persisted = persistedNumlockState()
+    if persisted ~= nil then
+        return persisted
+    end
+
+    local reader = io.popen([[
+for path in /sys/class/leds/*::numlock/brightness; do
+    [ -r "$path" ] && cat "$path"
+done
+]])
+    if not reader then
+        return true
+    end
+
+    local found = false
+    local enabled = false
+    for value in reader:lines() do
+        found = true
+        if value:match("^%s*1%s*$") then
+            enabled = true
+        end
+    end
+    reader:close()
+
+    if not found then
+        return true
+    end
+    return enabled
+end
+
 hl.monitor({
     output   = "",
     mode     = "preferred",
@@ -18,6 +102,9 @@ hl.monitor({
 })
 
 hl.config({
+    input = {
+        numlock_by_default = inheritedNumlockState(),
+    },
     misc = {
         disable_hyprland_logo    = true,
         disable_splash_rendering = true,


### PR DESCRIPTION
## Describe your changes

Closes #4.

Preserve the user's actual Num Lock choice across SDDM/user-session compositor
handoffs and full reboots:

- save the resulting LED state after each real `Num_Lock` key event through a
  non-consuming Hyprland binding;
- store the value atomically as `0` or `1` under
  `~/.local/state/mainstream/numlock`;
- restore it when the user-session Hyprland config is evaluated;
- let SDDM's separate Hyprland instance restore the last logged-in user's value;
- fall back to the current sysfs LED state, and finally to the existing enabled
  default when no usable state is available.

The save operation intentionally runs only after a physical Num Lock event.
There is no startup write: doing that can capture a compositor's transitional
LED state and overwrite the correct value before the first keypad input.

Multiple `*::numlock` LED endpoints are handled with “any enabled wins”, which
matches systems where one physical keyboard is exposed through several logical
input endpoints.

### Validation

- `bash -n dots/.config/hypr/hyprland/scripts/save-numlock-state.sh`
- `luac -p` on both changed Hyprland Lua files and the SDDM greeter config
- `Hyprland --verify-config --config sdata/sddm/hyprland.lua` (`config ok`)
- `git diff --check`
- manually verified enabled and disabled states across:
  - logout → SDDM → login;
  - full reboot → SDDM → login;
  - the first numeric-keypad input after login.

### Practical considerations

- The saved file contains only `0` or `1` and is mode `0644` so the SDDM user
  can read it; its containing state directory is mode `0755`.
- Pressing Num Lock starts one short-lived script with a 100 ms delay so the
  compositor has time to publish the resulting LED state. It does not run at
  startup or poll continuously.
- On a machine with no saved value and no readable Num Lock LED, behaviour
  remains the existing `numlock_by_default = true`.

## Is it ready? Questions/feedback needed?

Ready for review. Feedback is welcome on the last-user lookup through
`/var/lib/sddm/state.conf`, particularly for multi-user installations.
