### PR TITLE
fix(tray): keep overflow dismissible after context menu closes

### DIFF
--- a/dots/.config/quickshell/ii/modules/ii/bar/SysTray.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/SysTray.qml
@@ -39,7 +39,8 @@ Item {
     }
 
     function releaseFocus() {
-        focusGrab.active = false;
+        root.activeMenu = null;
+        focusGrab.active = root.trayOverflowOpen;
     }
 
     function closeOverflowMenu() {


### PR DESCRIPTION
## Describe your changes

Keep the tray overflow's `HyprlandFocusGrab` active when a tray item context menu closes while the overflow popup itself remains open.

The context-menu window is also cleared from `activeMenu` once it closes. Context menus opened from pinned tray icons retain the previous behavior because the focus grab is disabled when no overflow popup is open.

Closes #8.

## Testing

Tested locally on MainstreamOS 1.4.2 with Quickshell 0.3.1 and Hyprland 0.56.2:

1. Opened the tray overflow popup.
2. Opened an item context menu with right-click.
3. Dismissed the context menu without selecting an action.
4. Confirmed that clicking outside closes the overflow popup.
5. Confirmed the fix with the live Quickshell configuration after automatic reload.

## Is it ready? Questions/feedback needed?

Ready for review.
